### PR TITLE
Remove Kubernetes namespace creation and improve configuration for k8s namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=builder /go/bin/gops /home/appuser/bin
 # Required for openshift compatibility (the go process writes a config file to the home directory)
 RUN chmod g+w /home/appuser
 ENV HOME /home/appuser
-
+ENV BURNELL_CONFIG /home/appuser/config/burnell.yml
 USER appuser
 
 # Command to run the executable

--- a/config/burnell.yml
+++ b/config/burnell.yml
@@ -8,7 +8,8 @@ AdminRestPrefix: "/admin/v2"
 PulsarPublicKey: ./unit-test/example_public_key.pub
 PulsarPrivateKey: ./unit-test/example_private_key
 PulsarToken:
-PulsarURL : "pulsar+ssl://useast1.gcp.kafkaesque.io:6651"
+PulsarURL: "pulsar+ssl://useast1.gcp.kafkaesque.io:6651"
+PulsarNamespace: "pulsar"
 FederatedPromURL:
 SuperRoles: "superuser,anotheradmin"
 TenantManagmentTopic: "persistent://ming-luo/local-useast1-gcp/test-tenant-management"

--- a/config/burnell.yml.template
+++ b/config/burnell.yml.template
@@ -7,7 +7,8 @@ AdminRestPrefix: "/admin/v2"
 PulsarPublicKey:
 PulsarPrivateKey:
 PulsarToken:
-PulsarURL :
+PulsarURL:
+PulsarNamespace: "pulsar"
 FederatedPromURL:
 SuperRoles:
 TenantManagmentTopic: "persistent://ming-luo/local-useast1-gcp/test-tenant-management"

--- a/src/k8s/clientset.go
+++ b/src/k8s/clientset.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package k8s
 
@@ -36,17 +36,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	metrics "k8s.io/metrics/pkg/client/clientset/versioned"
-)
-
-const (
-	// DefaultPulsarNamespace is the default pulsar namespace in the cluster
-	DefaultPulsarNamespace = "pulsar"
-
-	// PulsarNamespacePrefix is the prefix of the Pulsar cluster namespace
-	PulsarNamespacePrefix = "pulsar-"
-
-	// DeployerNamespace is the deployer namespace
-	DeployerNamespace = "deployer"
 )
 
 // Client is the k8s client object
@@ -183,45 +172,6 @@ func (c *Client) VerifySecret(k8sNamespace, secretName string) error {
 		return nil
 	}
 	return fmt.Errorf("unable to find secret %s under namespace %s", secretName, k8sNamespace)
-}
-
-// GetNamespacesNames gets names of all namespaces
-func (c *Client) GetNamespacesNames() (map[string]bool, error) {
-	names := make(map[string]bool)
-	namespaces := c.Clientset.CoreV1().Namespaces()
-	nsList, err := namespaces.List(context.TODO(), meta_v1.ListOptions{})
-	if err != nil {
-		return names, nil
-	}
-	for _, item := range nsList.Items {
-		names[item.ObjectMeta.Name] = true
-	}
-	return names, nil
-}
-
-// CreatePulsarNamespace creates a namespace for a Pulsar cluster, return namespace name
-func (c *Client) CreatePulsarNamespace(name string) (string, error) {
-	nsMap, err := c.GetNamespacesNames()
-	if err != nil {
-		return "", err
-	}
-
-	namespaceName := name
-	if nsMap[namespaceName] {
-		return namespaceName, fmt.Errorf("namespace %s already exists", namespaceName)
-	}
-
-	namespaces := c.Clientset.CoreV1().Namespaces()
-	nsSpec := &core_v1.Namespace{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: namespaceName,
-		},
-	}
-	_, err = namespaces.Create(context.TODO(), nsSpec, meta_v1.CreateOptions{})
-	if err != nil {
-		return "", err
-	}
-	return namespaceName, nil
 }
 
 func (c *Client) getDeployments(namespace, component string) (*v1.DeploymentList, error) {

--- a/src/policy/topic-stats.go
+++ b/src/policy/topic-stats.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package policy
 
@@ -333,7 +333,7 @@ func getTopicsFromNamespace(path string, isPersistent bool) ([]string, error) {
 
 	if response.StatusCode != http.StatusOK {
 		statsLog.Errorf("GET topics under namespace %s response status code %d", requestBrokersURL, response.StatusCode)
-		return nil, fmt.Errorf("GET topics under namesapce response status code %d", response.StatusCode)
+		return nil, fmt.Errorf("GET topics under namespace response status code %d", response.StatusCode)
 	}
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/src/workflow/keys-jwt.go
+++ b/src/workflow/keys-jwt.go
@@ -162,7 +162,7 @@ func (m *Cluster) Create() error {
 		return err
 	}
 	m.KeysAndJWT.Status = Succeeded
-	m.l.Infof("keys and tokens are created and exported to kubernets secrets")
+	m.l.Infof("keys and tokens are created and exported to kubernetes secrets")
 	return nil
 }
 
@@ -218,7 +218,7 @@ func (kj *KeysJWTs) Create(k8sNamespace, privateKeyName, publicKeyName string) e
 		map[string][]byte{
 			publicKeyName: kj.KeyManager.PublicKeyPKIXBytes,
 		})
-	kj.l.Infof("successfully exported token private and public key as k8s secrets under namesapce %s", k8sNamespace)
+	kj.l.Infof("successfully exported token private and public key as k8s secrets under namespace %s", k8sNamespace)
 
 	for _, v := range getAdminRoles() {
 		role := strings.TrimSpace(v)
@@ -234,7 +234,7 @@ func (kj *KeysJWTs) Create(k8sNamespace, privateKeyName, publicKeyName string) e
 			role + JWTFileExtension: []byte(tokenString),
 		}
 		k8s.LocalClient.CreateSecret(k8sNamespace, k8sSecretName, data)
-		kj.l.Infof("successfully exported %s token to secret %s under k8s namesapce %s", role, k8sSecretName, k8sNamespace)
+		kj.l.Infof("successfully exported %s token to secret %s under k8s namespace %s", role, k8sSecretName, k8sNamespace)
 	}
 
 	return nil


### PR DESCRIPTION
- Burnell shouldn't create the Kubernetes namespace
  - remove logic to create Kubernetes namespace 
- Use `ENV BURNELL_CONFIG /home/appuser/config/burnell.yml` to set default config location explicitly in the Docker container
- Remove some unused constants